### PR TITLE
Fixed `determinant_fast()`

### DIFF
--- a/LinearAlgebraPurePython.py
+++ b/LinearAlgebraPurePython.py
@@ -326,15 +326,20 @@ def determinant_fast(A):
     AM = copy_matrix(A)
 
     # Section 2: Row manipulate A into an upper triangle matrix
+    odd_swaps = False
     for fd in range(n):  # fd stands for focus diagonal
         if AM[fd][fd] == 0: # Do a row swap with a row that won't result in a pivot of 0
+            found = False
             for i in range(fd+1,n):
                 if AM[i][fd] != 0:
                     temp = AM[fd]
                     AM[fd] = AM[i]
                     AM[i] = temp
+                    found = True
+                    odd_swaps = not odd_swaps
                     break
-            return 0 # If there are no other rows that can do that then return the determinant of 0
+            if not found:
+                return 0 # If there are no other rows that can do that then return the determinant of 0
         for i in range(fd+1, n):  # skip row with fd in it.
             crScaler = AM[i][fd] / AM[fd][fd]  # cr stands for "current row".
             for j in range(n):  # cr - crScaler * fdRow, one element at a time.
@@ -344,7 +349,8 @@ def determinant_fast(A):
     product = 1.0
     for i in range(n):
         product *= AM[i][i]  # ... product of diagonals is determinant
-
+    if odd_swaps:
+        product *= -1
     return product
 
 

--- a/LinearAlgebraPurePython.py
+++ b/LinearAlgebraPurePython.py
@@ -327,8 +327,14 @@ def determinant_fast(A):
 
     # Section 2: Row manipulate A into an upper triangle matrix
     for fd in range(n):  # fd stands for focus diagonal
-        if AM[fd][fd] == 0:
-            AM[fd][fd] = 1.0e-18  # Cheating by adding zero + ~zero
+        if AM[fd][fd] == 0: # Do a row swap with a row that won't result in a pivot of 0
+            for i in range(fd+1,n):
+                if AM[i][fd] != 0:
+                    temp = AM[fd]
+                    AM[fd] = AM[i]
+                    AM[i] = temp
+                    break
+            return 0 # If there are no other rows that can do that then return the determinant of 0
         for i in range(fd+1, n):  # skip row with fd in it.
             crScaler = AM[i][fd] / AM[fd][fd]  # cr stands for "current row".
             for j in range(n):  # cr - crScaler * fdRow, one element at a time.


### PR DESCRIPTION
## The Algorithm's Issue
When trying to implement the matrix multiplication algorithm in this library (getting the REF (Row Echelon Form) with Gaussian Elimination and then multiplying the main diagonal for the determinant) I found the issue with `determinant_fast()` that was also mentioned by issue https://github.com/ThomIves/BasicLinearAlgebraToolsPurePy/issues/2.
The pivot being 0 would cause `determinant_fast()` to return the wrong determinant due to the lack of row swapping.

## The Fix
This pull request fixes that by adding row swapping like this on [line 331](https://github.com/RandomGamingDev/BasicLinearAlgebraToolsPurePy/blob/master/LinearAlgebraPurePython.py#L331C27-L331C27):
```py
            found = False
            for i in range(fd+1,n):
                if AM[i][fd] != 0:
                    temp = AM[fd]
                    AM[fd] = AM[i]
                    AM[i] = temp
                    found = True
                    odd_swaps = not odd_swaps
                    break
            if not found:
                return 0 # If there are no other rows that can do that then return the determinant of 0
```
alongside the `odd_swaps` variable for check whether there's been an odd number of swaps and the negator at the end for if there has been an odd number of swaps.
and removing the "cheat":
```py
            AM[fd][fd] = 1.0e-18  # Cheating by adding zero + ~zero
```

from [here](https://github.com/ThomIves/BasicLinearAlgebraToolsPurePy/blob/533263e946b83ee49f1dc48fd4b606e2b37c408e/LinearAlgebraPurePython.py#L331C15-L331C15)

## The Mistake
Contrary to what's said in the [article](https://integratedmlai.com/find-the-determinant-of-a-matrix-with-pure-python-without-numpy-or-scipy/):
>"(I did develop a fancy way to reorder rows based on the number of leading zeros and keep track of how many times that was done, so that I could change the final sign of the determinant, but DANG! Just more code and more steps. Cheating was better!"

the cheat and fancy system that includes keeping track of the number of times rows were swapped to change the sign at the end isn't required, all that's required is row swapping and a boolean to tell whether or not there's been an odd number of swaps.

## Please update the article
https://integratedmlai.com/find-the-determinant-of-a-matrix-with-pure-python-without-numpy-or-scipy/

## The Solution for those who are trying to use the algorithm
The author doesn't appear to be active on his github, so hopefully this'll help anyone who's confused
just copy `determinant_fast()` from my pull request here: https://github.com/RandomGamingDev/BasicLinearAlgebraToolsPurePy/blob/master/LinearAlgebraPurePython.py#L315

## How can I contact @ThomIves 
Also, I don't know how to contact the author so it'd be appreciated if someone who did know could help contact him or send his contact details to me so that we can update the article.